### PR TITLE
Added the ability for encoders with half steps.

### DIFF
--- a/rotary_irq_esp.py
+++ b/rotary_irq_esp.py
@@ -16,7 +16,7 @@ _esp8266_deny_pins = [16]
 
 class RotaryIRQ(Rotary): 
     
-    def __init__(self, pin_num_clk, pin_num_dt, min_val=0, max_val=10, reverse=False, range_mode=Rotary.RANGE_UNBOUNDED, pull_up=False):
+    def __init__(self, pin_num_clk, pin_num_dt, min_val=0, max_val=10, reverse=False, range_mode=Rotary.RANGE_UNBOUNDED, pull_up=False, half_step=False):
         
         if platform == 'esp8266':
             if pin_num_clk in _esp8266_deny_pins:
@@ -24,7 +24,7 @@ class RotaryIRQ(Rotary):
             if pin_num_dt in _esp8266_deny_pins:
                 raise ValueError('%s: Pin %d not allowed. Not Available for Interrupt: %s' % (platform, pin_num_dt,_esp8266_deny_pins))
 
-        super().__init__(min_val, max_val, reverse, range_mode)
+        super().__init__(min_val, max_val, reverse, range_mode, half_step)
         
         if pull_up == True:
             self._pin_clk = Pin(pin_num_clk, Pin.IN, Pin.PULL_UP)
@@ -34,7 +34,7 @@ class RotaryIRQ(Rotary):
             self._pin_dt = Pin(pin_num_dt, Pin.IN)
 
         self._enable_clk_irq(self._process_rotary_pins)        
-        self._enable_dt_irq(self._process_rotary_pins)   
+        self._enable_dt_irq(self._process_rotary_pins)
         
     def _enable_clk_irq(self, callback=None):
         self._pin_clk.irq(trigger=Pin.IRQ_RISING | Pin.IRQ_FALLING, handler=callback)
@@ -56,11 +56,11 @@ class RotaryIRQ(Rotary):
     
     def _hal_enable_irq(self):
         self._enable_clk_irq(self._process_rotary_pins)        
-        self._enable_dt_irq(self._process_rotary_pins)   
+        self._enable_dt_irq(self._process_rotary_pins)
 
     def _hal_disable_irq(self): 
         self._disable_clk_irq()
-        self._disable_dt_irq()     
+        self._disable_dt_irq()
 
     def _hal_close(self):
         self._hal_disable_irq()

--- a/rotary_irq_pyb.py
+++ b/rotary_irq_pyb.py
@@ -15,8 +15,8 @@ from rotary import Rotary
 
 class RotaryIRQ(Rotary):   
     
-    def __init__(self, pin_num_clk, pin_num_dt, min_val=0, max_val=10, reverse=False, range_mode=Rotary.RANGE_UNBOUNDED, pull_up=False):
-        super().__init__(min_val, max_val, reverse, range_mode)
+    def __init__(self, pin_num_clk, pin_num_dt, min_val=0, max_val=10, reverse=False, range_mode=Rotary.RANGE_UNBOUNDED, pull_up=False, half_step=False):
+        super().__init__(min_val, max_val, reverse, range_mode, half_step)
         
         if pull_up == True:
             self._pin_clk = Pin(pin_num_clk, Pin.IN, Pin.PULL_UP)


### PR DESCRIPTION
Hi,
I'm added the abilitya to use encoders with half steps.

Example:
```python
import time
from rotary_irq_esp import RotaryIRQ

r = RotaryIRQ(pin_num_clk=12, 
              pin_num_dt=13, 
              min_val=0, 
              max_val=5, 
              reverse=False, 
              range_mode=RotaryIRQ.RANGE_WRAP,
              half_step=True)