### PR TITLE
Update rotary.py

### DIFF
--- a/rotary.py
+++ b/rotary.py
@@ -28,10 +28,10 @@ _transition_table = [
     # CLK/DT    CLK/DT     CLK/DT    CLK/DT
     #   00        01         10        11
     [_R_START, _R_CCW_1, _R_CW_1,  _R_START],             # _R_START
-    [_R_CW_2,  _R_START, _R_CW_1,  _R_START],             # _R_CW_1
+    [_R_CW_2,  _R_START, _R_CW_1,  _R_START | _DIR_CCW],  # _R_CW_1
     [_R_CW_2,  _R_CW_3,  _R_CW_1,  _R_START],             # _R_CW_2
     [_R_CW_2,  _R_CW_3,  _R_START, _R_START | _DIR_CW],   # _R_CW_3
-    [_R_CCW_2, _R_CCW_1, _R_START, _R_START],             # _R_CCW_1
+    [_R_CCW_2, _R_CCW_1, _R_START, _R_START | _DIR_CW],   # _R_CCW_1
     [_R_CCW_2, _R_CCW_1, _R_CCW_3, _R_START],             # _R_CCW_2
     [_R_CCW_2, _R_START, _R_CCW_3, _R_START | _DIR_CCW],  # _R_CCW_3
     [_R_START, _R_START, _R_START, _R_START]]             # _R_ILLEGAL


### PR DESCRIPTION
Modified state table to fix issue with missed step when changing encoder direction as discussed in this issue thread:
https://github.com/miketeachman/micropython-rotary/issues/10

Not sure how this affects the 'half_step' state table